### PR TITLE
REBASE from main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Matrix Screensaver
 
-![Build Status](https://github.com/yourusername/MatrixScreen/workflows/Continuous%20Integration/badge.svg)
+[![Continuous Integration](https://github.com/SOELexicon/MatrixScreen/actions/workflows/ci.yml/badge.svg)](https://github.com/SOELexicon/MatrixScreen/actions/workflows/ci.yml)
 [![Build and Release](https://github.com/SOELexicon/MatrixScreen/actions/workflows/release.yml/badge.svg)](https://github.com/SOELexicon/MatrixScreen/actions/workflows/release.yml)
 
 A high-performance Matrix digital rain screensaver written in modern C++20 with DirectX 11 hardware acceleration.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Matrix Screensaver
 
 ![Build Status](https://github.com/yourusername/MatrixScreen/workflows/Continuous%20Integration/badge.svg)
-![Release](https://github.com/yourusername/MatrixScreen/workflows/Build%20and%20Release/badge.svg)
+[![Build and Release](https://github.com/SOELexicon/MatrixScreen/actions/workflows/release.yml/badge.svg)](https://github.com/SOELexicon/MatrixScreen/actions/workflows/release.yml)
 
 A high-performance Matrix digital rain screensaver written in modern C++20 with DirectX 11 hardware acceleration.
 


### PR DESCRIPTION
This pull request updates the build and release status badges in the `README.md` file to point to the correct GitHub Actions workflows under the `SOELexicon/MatrixScreen` repository.

Documentation update:

* Updated the Continuous Integration and Build and Release badges in `README.md` to use the correct workflow URLs and badge formats for the current repository.